### PR TITLE
Keep eudev as udev dependency for elogind-255

### DIFF
--- a/sys-auth/elogind/elogind-255.24.ebuild
+++ b/sys-auth/elogind/elogind-255.24.ebuild
@@ -1,0 +1,200 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..14} )
+
+if [[ ${PV} = *9999* ]]; then
+	EGIT_BRANCH="v255-stable"
+	EGIT_REPO_URI="https://github.com/elogind/elogind.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/${PN}/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
+fi
+
+inherit eapi9-ver linux-info meson pam python-any-r1 udev xdg-utils
+
+DESCRIPTION="The systemd project's logind, extracted to a standalone package"
+HOMEPAGE="https://github.com/elogind/elogind"
+
+LICENSE="CC0-1.0 LGPL-2.1+ public-domain"
+SLOT="0"
+IUSE="+acl audit cgroup-hybrid debug doc +pam +policykit selinux test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	app-text/docbook-xml-dtd:4.2
+	app-text/docbook-xml-dtd:4.5
+	app-text/docbook-xsl-stylesheets
+	dev-util/gperf
+	virtual/pkgconfig
+	$(python_gen_any_dep 'dev-python/jinja2[${PYTHON_USEDEP}]')
+	$(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]')
+"
+DEPEND="
+	audit? ( sys-process/audit )
+	sys-apps/util-linux
+	sys-libs/libcap
+	virtual/libudev:=
+	acl? ( sys-apps/acl )
+	pam? ( sys-libs/pam )
+	selinux? ( sys-libs/libselinux )
+"
+RDEPEND="${DEPEND}
+	!sys-apps/systemd
+	sys-fs/eudev
+"
+PDEPEND="
+	sys-apps/dbus
+	policykit? ( sys-auth/polkit )
+"
+
+DOCS=( README.md )
+
+PATCHES=(
+	# all downstream patches:
+	"${FILESDIR}/${PN}-252.9-nodocs.patch"
+	# See also:
+	# https://github.com/elogind/elogind/issues/285
+	"${FILESDIR}/${PN}-255.17-revert-s2idle.patch" # bug 939042
+	"${FILESDIR}/${PN}-255.22-musl.patch" # bug 967191
+	"${FILESDIR}/${PN}-255.22-musl-deux.patch" # bug 967711
+)
+
+python_check_deps() {
+	python_has_version "dev-python/jinja2[${PYTHON_USEDEP}]" &&
+	python_has_version "dev-python/lxml[${PYTHON_USEDEP}]"
+}
+
+pkg_setup() {
+	local CONFIG_CHECK="~CGROUPS ~EPOLL ~INOTIFY_USER ~SIGNALFD ~TIMERFD"
+
+	use kernel_linux && linux-info_pkg_setup
+}
+
+src_prepare() {
+	default
+	xdg_environment_reset
+
+	# don't cleanup /dev/shm/ on logout on logout
+	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949698
+	sed -e "s/#RemoveIPC=yes/RemoveIPC=no/" \
+		-i src/login/logind.conf.in || die
+}
+
+src_configure() {
+	if use cgroup-hybrid; then
+		cgroupmode="hybrid"
+	else
+		cgroupmode="unified"
+	fi
+
+	python_setup
+
+	EMESON_BUILDTYPE="$(usex debug debug release)"
+
+	local emesonargs=(
+		-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
+		-Dhtmldir="${EPREFIX}/usr/share/doc/${PF}/html"
+		-Dudevrulesdir="${EPREFIX}$(get_udevdir)"/rules.d
+		--libexecdir="lib/elogind"
+		--localstatedir="${EPREFIX}"/var
+		-Dbashcompletiondir="${EPREFIX}/usr/share/bash-completion/completions"
+		-Dman=auto
+		-Dsmack=true
+		-Dcgroup-controller=openrc
+		-Ddefault-hierarchy=${cgroupmode}
+		-Ddefault-kill-user-processes=false
+		-Dacl=$(usex acl enabled disabled)
+		-Daudit=$(usex audit enabled disabled)
+		-Dhtml=$(usex doc auto disabled)
+		-Dpam=$(usex pam enabled disabled)
+		-Dpamlibdir="$(getpam_mod_dir)"
+		-Dselinux=$(usex selinux enabled disabled)
+		-Dtests=$(usex test true false)
+		-Dutmp=$(usex elibc_musl false true)
+		-Dmode=release
+
+		# Ensure consistency between merged-usr and split-usr (bug 945965)
+		-Dhalt-path="${EPREFIX}/sbin/halt"
+		-Dkexec-path="${EPREFIX}/usr/sbin/kexec"
+		-Dnologin-path="${EPREFIX}/sbin/nologin"
+		-Dpoweroff-path="${EPREFIX}/sbin/poweroff"
+		-Dreboot-path="${EPREFIX}/sbin/reboot"
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	keepdir /var/lib/elogind
+
+	newinitd "${FILESDIR}"/${PN}.init-r1 ${PN}
+
+	newconfd "${FILESDIR}"/${PN}.conf ${PN}
+}
+
+pkg_postinst() {
+	udev_reload
+	if ! use pam; then
+		ewarn "${PN} will not be managing user logins/seats without USE=\"pam\"!"
+		ewarn "In other words, it will be useless for most applications."
+		ewarn
+	fi
+	if ! use policykit; then
+		ewarn "loginctl will not be able to perform privileged operations without"
+		ewarn "USE=\"policykit\"! That means e.g. no suspend or hibernate."
+		ewarn
+	fi
+	if [[ "$(rc-config list boot | grep elogind)" != "" ]]; then
+		elog "elogind is currently started from boot runlevel."
+	elif [[ "$(rc-config list default | grep elogind)" != "" ]]; then
+		ewarn "elogind is currently started from default runlevel."
+		ewarn "Please remove elogind from the default runlevel and"
+		ewarn "add it to the boot runlevel by:"
+		ewarn "# rc-update del elogind default"
+		ewarn "# rc-update add elogind boot"
+	else
+		elog "elogind is currently not started from any runlevel."
+		elog "You may add it to the boot runlevel by:"
+		elog "# rc-update add elogind boot"
+		elog
+		elog "Alternatively, you can leave elogind out of any"
+		elog "runlevel. It will then be started automatically"
+		if use pam; then
+			elog "when the first service calls it via dbus, or"
+			elog "the first user logs into the system."
+		else
+			elog "when the first service calls it via dbus."
+		fi
+	fi
+
+	if ver_replacing -lt 252.9; then
+		elog "Starting with release 252.9 the sleep configuration is now done"
+		elog "in the /etc/elogind/sleep.conf. Should you use non-default sleep"
+		elog "configuration remember to migrate those to new configuration file."
+	fi
+
+	local file files
+	# find custom hooks excluding known (nvidia-drivers, sys-power/tlp)
+	if [[ -d "${EROOT}"/$(get_libdir)/elogind/system-sleep ]]; then
+		readarray -t files < <(find "${EROOT}"/$(get_libdir)/elogind/system-sleep/ \
+			-type f \( -not -iname ".keep_dir" -a \
+				-not -iname "nvidia" -a \
+				-not -iname "49-tlp-sleep" \) || die)
+	fi
+	if [[ ${#files[@]} -gt 0 ]]; then
+		ewarn "*** Custom hooks in obsolete path detected ***"
+		for file in "${files[@]}"; do
+			ewarn "    ${file}"
+		done
+		ewarn "Move these custom hooks to ${EROOT}/etc/elogind/system-sleep/ instead."
+	fi
+}
+
+pkg_postrm() {
+	udev_reload
+}

--- a/sys-auth/elogind/files/elogind-252.9-nodocs.patch
+++ b/sys-auth/elogind/files/elogind-252.9-nodocs.patch
@@ -1,0 +1,28 @@
+diff --git a/meson.build b/meson.build
+index 694a2fd97..9b97cafef 100644
+--- a/meson.build
++++ b/meson.build
+@@ -4528,15 +4528,11 @@ subdir('shell-completion/zsh')
+ #                      install_dir : xinitrcdir)
+ # endif
+ #endif // 0
+-install_data('LICENSE.GPL2',
+-             'LICENSE.LGPL2.1',
+ #if 0 /// elogind has upgraded to markdown, and the NEWS file is useless
+ #              'NEWS',
+ #              'README',
+ #else // 0
+-             'README.md',
+ #endif // 0
+-             'docs/CODING_STYLE.md',
+ #if 0 /// irrelevant for elogind
+ #              'docs/DISTRO_PORTING.md',
+ #              'docs/ENVIRONMENT.md',
+@@ -4545,7 +4541,6 @@ install_data('LICENSE.GPL2',
+ #              'docs/TRANSLATORS.md',
+ #              'docs/UIDS-GIDS.md',
+ #endif // 0
+-             install_dir : docdir)
+ 
+ #if 0 /// irrelevant for elogind
+ # install_subdir('LICENSES',

--- a/sys-auth/elogind/files/elogind-255.17-revert-s2idle.patch
+++ b/sys-auth/elogind/files/elogind-255.17-revert-s2idle.patch
@@ -1,0 +1,55 @@
+From 484126708da24d1611cb0697c6e3a20088b1a839 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Tue, 12 Nov 2024 23:43:16 +0100
+Subject: [PATCH] Revert "Re-Add sleep mode configuration"
+
+This reverts commit 7707a30dfb2496a4c9c5939f0dd8bb39baebfecd.
+
+sleep.donf.d/10-elogind.conf: Revert set SuspendMode=s2idle deep
+
+This reverts a tiny part of commit c5e7ba0c47ae95e2cf6fd48dc9353e8f333200c4.
+---
+ src/shared/sleep-config.c | 8 --------
+ src/sleep/10-elogind.conf | 1 -
+ 2 files changed, 9 deletions(-)
+
+diff --git a/src/shared/sleep-config.c b/src/shared/sleep-config.c
+index 941a013eb..27f2fcd76 100644
+--- a/src/shared/sleep-config.c
++++ b/src/shared/sleep-config.c
+@@ -42,11 +42,7 @@ static char* const* const sleep_default_state_table[_SLEEP_OPERATION_CONFIG_MAX]
+ };
+ 
+ static char* const* const sleep_default_mode_table[_SLEEP_OPERATION_CONFIG_MAX] = {
+-#if 0 /// elogind supports suspend modes (deep s2idle) so we need defaults, too
+         /* Not used by SLEEP_SUSPEND */
+-#else // 0
+-        [SLEEP_SUSPEND]      = STRV_MAKE("deep", "s2idle"),
+-#endif // 0
+         [SLEEP_HIBERNATE]    = STRV_MAKE("platform", "shutdown"),
+         [SLEEP_HYBRID_SLEEP] = STRV_MAKE("suspend"),
+ };
+@@ -172,11 +168,7 @@ int parse_sleep_config(SleepConfig **ret) {
+                 { "Sleep", "AllowHybridSleep",          config_parse_tristate,    0,               &allow_hybrid_sleep          },
+ 
+                 { "Sleep", "SuspendState",              config_parse_strv,        0,               sc->states + SLEEP_SUSPEND   },
+-#if 0 /// elogind does support suspend modes
+                 { "Sleep", "SuspendMode",               config_parse_warn_compat, DISABLED_LEGACY, NULL                         },
+-#else // 0
+-                { "Sleep", "SuspendMode",               config_parse_sleep_mode,  0,               sc->modes + SLEEP_SUSPEND    },
+-#endif // 0
+ 
+                 { "Sleep", "HibernateState",            config_parse_warn_compat, DISABLED_LEGACY, NULL                         },
+                 { "Sleep", "HibernateMode",             config_parse_sleep_mode,  0,               sc->modes + SLEEP_HIBERNATE  },
+diff --git a/src/sleep/10-elogind.conf b/src/sleep/10-elogind.conf
+index 4d4e29bea..6c9cbd477 100644
+--- a/src/sleep/10-elogind.conf
++++ b/src/sleep/10-elogind.conf
+@@ -19,4 +19,3 @@
+ #HandleNvidiaSleep=no
+ #HibernateByUsing=
+ #SuspendByUsing=
+-#SuspendMode=deep s2idle
+-- 
+2.51.2
+

--- a/sys-auth/elogind/files/elogind-255.22-musl-deux.patch
+++ b/sys-auth/elogind/files/elogind-255.22-musl-deux.patch
@@ -1,0 +1,54 @@
+https://bugs.gentoo.org/967711#c5
+
+From 182f0406205b2d9302f555a1afb52d6f70dc488e Mon Sep 17 00:00:00 2001
+From: "David C. Manuelda" <StormByte@gmail.com>
+Date: Sun, 19 Apr 2026 23:31:25 +0200
+Subject: [PATCH] Musl fixes
+
+---
+ src/basic/missing_prctl.h                | 3 +++
+ src/libelogind/sd-journal/journal-file.h | 1 +
+ src/shared/user-record-nss.h             | 1 -
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/basic/missing_prctl.h b/src/basic/missing_prctl.h
+index 7d9e395..80d9af3 100644
+--- a/src/basic/missing_prctl.h
++++ b/src/basic/missing_prctl.h
+@@ -1,7 +1,10 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
++#include <sys/prctl.h>
++#ifndef PR_SET_MM_MAP
+ #include <linux/prctl.h>
++#endif
+ 
+ /* 58319057b7847667f0c9585b9de0e8932b0fdb08 (4.3) */
+ #ifndef PR_CAP_AMBIENT
+diff --git a/src/libelogind/sd-journal/journal-file.h b/src/libelogind/sd-journal/journal-file.h
+index c3c5f59..3e62495 100644
+--- a/src/libelogind/sd-journal/journal-file.h
++++ b/src/libelogind/sd-journal/journal-file.h
+@@ -3,6 +3,7 @@
+ 
+ #include <fcntl.h>
+ #include <inttypes.h>
++#include <sys/stat.h>
+ //#include <sys/uio.h>
+ 
+ #if HAVE_GCRYPT
+diff --git a/src/shared/user-record-nss.h b/src/shared/user-record-nss.h
+index 7a41be7..3a970a6 100644
+--- a/src/shared/user-record-nss.h
++++ b/src/shared/user-record-nss.h
+@@ -2,7 +2,6 @@
+ #pragma once
+ 
+ #include <grp.h>
+-#include <gshadow.h>
+ #include <pwd.h>
+ #include <shadow.h>
+ 
+-- 
+2.53.0

--- a/sys-auth/elogind/files/elogind-255.22-musl.patch
+++ b/sys-auth/elogind/files/elogind-255.22-musl.patch
@@ -1,0 +1,86 @@
+https://github.com/elogind/elogind/commit/c09b9caece0459ec56b234a87583e1bfac3c3271
+
+From c09b9caece0459ec56b234a87583e1bfac3c3271 Mon Sep 17 00:00:00 2001
+From: Sven Eden <sven@eden-worx.com>
+Date: Thu, 20 Nov 2025 08:12:12 +0100
+Subject: [PATCH] journal-send.c, bus-error.c: Fix strerror_r handling for
+ non-GLIBC systems
+
+Fix the handling of `strerror_r` in non-GLIBC systems to ensure compatibility.
+
+- Handle `strerror_r` differently for non-GLIBC systems in `journal-send.c`.
+- Handle `strerror_r` differently for non-GLIBC systems in `bus-error.c`.
+- Remove redundant definition of `strerror_r` from `musl_missing.h`.
+
+This change ensures that the `strerror_r` function behaves correctly across different environments, particularly on systems using the musl C library.
+
+Bug: #320
+Closes: #320
+Signed-off-by: Sven Eden <sven@eden-worx.com>
+---
+ src/basic/musl_missing.h                 |  2 --
+ src/libelogind/sd-bus/bus-error.c        | 10 ++++++++++
+ src/libelogind/sd-journal/journal-send.c |  5 +++++
+ 3 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/basic/musl_missing.h b/src/basic/musl_missing.h
+index d8a5bff222..3f592f1c6f 100644
+--- a/src/basic/musl_missing.h
++++ b/src/basic/musl_missing.h
+@@ -26,8 +26,6 @@ void elogind_set_program_name(const char* pcall);
+ #include <unistd.h>
+ #include <pthread.h> /* for pthread_atfork */
+ 
+-#define strerror_r(e, m, k) (strerror_r(e, m, k) < 0 ? strdup("strerror_r() failed") : m);
+-
+ /*
+  * Possibly TODO according to http://man7.org/linux/man-pages/man3/getenv.3.html
+  * + test if the process's effective user ID does not match its real user ID or
+diff --git a/src/libelogind/sd-bus/bus-error.c b/src/libelogind/sd-bus/bus-error.c
+index 58c24d25c0..4895bd3c66 100644
+--- a/src/libelogind/sd-bus/bus-error.c
++++ b/src/libelogind/sd-bus/bus-error.c
+@@ -405,7 +405,12 @@ static void bus_error_strerror(sd_bus_error *e, int error) {
+                         return;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(error, m, k);
++                x = m;
++#else // __GLIBC__
+                 x = strerror_r(error, m, k);
++#endif // __GLIBC__
+                 if (errno == ERANGE || strlen(x) >= k - 1) {
+                         free(m);
+                         k *= 2;
+@@ -591,7 +596,12 @@ const char* _bus_error_message(const sd_bus_error *e, int error, char buf[static
+         if (e && e->message)
+                 return e->message;
+ 
++#ifndef __GLIBC__
++        strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++        return buf;
++#else // __GLIBC__
+         return strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++#endif // __GLIBC__
+ }
+ 
+ static bool map_ok(const sd_bus_error_map *map) {
+diff --git a/src/libelogind/sd-journal/journal-send.c b/src/libelogind/sd-journal/journal-send.c
+index f0a0190a5b..6bfa2211f3 100644
+--- a/src/libelogind/sd-journal/journal-send.c
++++ b/src/libelogind/sd-journal/journal-send.c
+@@ -424,7 +424,12 @@ static int fill_iovec_perror_and_send(const char *message, int skip, struct iove
+                 char* j;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++                j = buffer + 8 + k;
++#else // __GLIBC__
+                 j = strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++#endif // __GLIBC__
+                 if (errno == 0) {
+                         char error[STRLEN("ERRNO=") + DECIMAL_STR_MAX(int) + 1];
+ 
+

--- a/sys-auth/elogind/files/elogind.conf
+++ b/sys-auth/elogind/files/elogind.conf
@@ -1,0 +1,7 @@
+# /etc/conf.d/elogind: config file for /etc/init.d/elogind
+
+# this is the elogind executable
+ELOGIND_EXEC="/usr/lib/elogind/elogind"
+
+# this is where elogind will store its pid file
+ELOGIND_PIDFILE="/run/elogind.pid"

--- a/sys-auth/elogind/files/elogind.init-r1
+++ b/sys-auth/elogind/files/elogind.init-r1
@@ -1,0 +1,27 @@
+#!/sbin/openrc-run
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	need dbus
+
+	# Make sure elogind is up before xdm starts any dm
+	before xdm
+
+	use logger
+}
+
+start() {
+	ebegin "Starting elogind"
+
+	start-stop-daemon --start --quiet \
+		--pidfile "${ELOGIND_PIDFILE}" \
+		--exec "${ELOGIND_EXEC}" -- --daemon
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping elogind"
+	start-stop-daemon --stop --quiet --pidfile "${ELOGIND_PIDFILE}"
+	eend $?
+}

--- a/sys-auth/elogind/metadata.xml
+++ b/sys-auth/elogind/metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>asturm@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="cgroup-hybrid">Use hybrid cgroup hierarchy instead of unified (OpenRC's default).</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">elogind/elogind</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
Gentoo stabilized elogind 255, which needs systemd-utils. This ebuild pulls eudev instead.